### PR TITLE
Update comments

### DIFF
--- a/DefaultTranslationOrigin.cs
+++ b/DefaultTranslationOrigin.cs
@@ -60,12 +60,12 @@ public static class DefaultTranslationOrigin
     public const string AdaptiveMachineTranslation = "amt";
 
     /// <summary>
-    /// Adaptive machine translated content
+    /// Neural machine translated content
     /// </summary>
     public const string NeuralMachineTranslation = "nmt";
 
     /// <summary>
-    /// Adaptive machine translated content
+    /// Machine translated content
     /// </summary>
     public const string AutomaticTranslation = "automatic-translation";
 }


### PR DESCRIPTION
Is `mt` maybe just a synonym for `automatic-translation`?  Using it still shows "AT" in the UI.

This line also seems off:
```
    public const string ReverseAlignment = "Retrofit";
```